### PR TITLE
Allow the login form to submit an empty password

### DIFF
--- a/lib/nodejs/authentication.js
+++ b/lib/nodejs/authentication.js
@@ -8,9 +8,17 @@ var passport = require( "passport" ),
   passportLocal = require( "passport-local" ),
   config = require( "config" );
 
+// Passport strategy options.
+
+var strategyOptions = {
+  passReqToCallback: true,      // Call the strategy callback as `cb( req, ... )` instead of `cb( ... )`
+  usernameField: "last_name",   // A non-empty field to appease `passport-local`, but we ignore `username`
+  passwordField: "last_name",   // A non-empty field, and we ignore `password`; the actual password may be empty
+};
+
 // Create and attach the Passport strategy object.
 
-var strategy = new passportLocal( { passReqToCallback: true, usernameField: "last_name" }, function( req, username, password, done ) {
+var strategy = new passportLocal( strategyOptions, function( req, username, password, done ) {
 
   // Build the user object from the form properties.
 
@@ -24,6 +32,10 @@ var strategy = new passportLocal( { passReqToCallback: true, usernameField: "las
     instructor:
       req.body.instructor || req.query.instructor,
   };
+
+  // Get the actual password from the form.
+
+  password = req.body.password || req.query.password;
 
   // Check the password if one is configured. Instructors must provide a password.
 


### PR DESCRIPTION
Student logins don't require a password, but `passport-local` does require that the form's password field be non-empty. Students currently need to enter arbitrary text into the password field to be allowed to log in.

This change tells `passport-local` to take the password from the `last_name` field, ignores the password from `passport-local`, and finds the actual password in the form data.

@eric79, could you review? @youngca, @ambientosx, fyi.
