### PR TITLE
Add setListening(..) to kinetic view that can be called from app

### DIFF
--- a/support/client/lib/vwf/view/kineticjs.js
+++ b/support/client/lib/vwf/view/kineticjs.js
@@ -777,6 +777,10 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
             swipe.listenForSwipes( params );
         },
 
+        setListening: function( nodeID, listen ) {
+            this.state.nodes[ nodeID ].kineticObj.listening( listen );
+        },
+
         setChildListening: function( nodeID, childNames, listen ) {
             var node = this.state.nodes[ nodeID ];
 


### PR DESCRIPTION
This corresponds to branch `new-pov-ux` in the app repo.  Could you please test and code review each, @davideaster @landersk61 @youngca @ambientosx?

Things it should do:
- If no units exist, clicking `Launch Simulation` will ask you to create units
- If not pov unit has been chosen, it will ask you to click/tap the unit that you would like to be your pov.
- ... and then so on.

All units can be selected as pov, regardless of whether they are on the active layer or not.  During selection of the pov unit, the app is in a new mode, so all other modes are disabled (therefore users will not get tricked into deleting their pov unit if they are in `erase` mode).  And now selecting a unit via touch works, too.
