### PR TITLE
Keep many kinetic UI events view-side

### DIFF
--- a/support/client/lib/vwf/view/kineticjs.js
+++ b/support/client/lib/vwf/view/kineticjs.js
@@ -541,7 +541,7 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
                         // but then we added the events for the individual objects
                         // which appeared to work better.  We were getting duplicate events
                         // which is why I moved these events down inside a property
-                        // just in case they were needed for another apllication that
+                        // just in case they were needed for another application that
                         // is set up differently
 
                         if ( Boolean( propertyValue ) ) {

--- a/support/client/lib/vwf/view/kineticjs.js
+++ b/support/client/lib/vwf/view/kineticjs.js
@@ -43,6 +43,7 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
     var renderTimeout = 1000;    // ms between renders
     var mouseDown = false;
     var doRenderScene = false;
+    var eventHandlers = {};
 
     // Object implements tapHold behavior (kineticJS doesn't have a built-in one)
     var tapHold = { 
@@ -114,7 +115,10 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
 
     function fireTapHold() {
         if ( tapHold.node ) {
-            viewDriver.kernel.fireEvent( tapHold.node.ID, 'tapHold', [ tapHold.initialPosition ] );
+            fireViewEvent( "tapHold", {
+                nodeID: tapHold.node.ID,
+                initialPosition: tapHold.initialPosition
+            } );
             tapHold.cancel();
         }
     }
@@ -127,9 +131,14 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
         "swipedAcross": function( node, isTouchStart, eventData ) {
             if ( this.isListening && this.isSwipe( node ) ) {
                 if ( isTouchStart && this.touchStartIsTap ) {
-                    viewDriver.kernel.fireEvent( node.ID, 'tap', eventData );
+                    fireViewEvent( "tap", {
+                        nodeID: node.ID,
+                        eventData: eventData[ 0 ]
+                    } );
                 } else {
-                    viewDriver.kernel.fireEvent( node.ID, 'swipe', [ ] );
+                    fireViewEvent( "swipe", {
+                        nodeID: node.ID
+                    } );
                 }
             }
         },  
@@ -264,7 +273,10 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
             tapHold.cancel();
             activelyDrawing = false;
 
-            viewDriver.kernel.fireEvent( node.ID, 'pointerClick', eData.eventData );
+            fireViewEvent( "pointerClick", {
+                nodeID: node.ID,
+                eventData: eData.eventData[ 0 ]
+            } );
         } );
 
         node.kineticObj.on( "dblclick", function( evt ) {
@@ -274,7 +286,10 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
             tapHold.cancel();
             activelyDrawing = false;
 
-            viewDriver.kernel.fireEvent( node.ID, 'pointerDoubleClick', eData.eventData );
+            fireViewEvent( "pointerDoubleClick", {
+                nodeID: node.ID,
+                eventData: eData.eventData[ 0 ]
+            } );
         } );
         
         node.kineticObj.on( "dragstart", function( evt ) {
@@ -369,7 +384,10 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
             tapHold.cancel();
             activelyDrawing = false;
 
-            viewDriver.kernel.fireEvent( node.ID, 'tap', eData.eventData );
+            fireViewEvent( "tap", {
+                nodeID: node.ID,
+                eventData: eData.eventData[ 0 ]
+            } );
             swipe.swipedAcross( node, true, eData.eventData );
         } );
 
@@ -797,6 +815,10 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
                 var childWasRequested = child && ( childNames.indexOf( child.name() ) > -1 );
                 childWasRequested && child.listening( listen );
             }
+        },
+
+        on: function( eventName, callback ) {
+            eventHandlers[ eventName ] = callback;
         }
     } );
 
@@ -1886,5 +1908,12 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
         privateDrawingState.drawingObject.destroy();
         privateDrawingState.drawingObject = null;
         privateDrawingState.imageDataURL = null;
+    }
+
+    function fireViewEvent( eventName, parameters ) {
+        var eventHandler = eventHandlers[ eventName ];
+        if ( typeof eventHandler === "function" ) {
+            eventHandler( parameters );
+        }
     }
 } );

--- a/support/proxy/vwf.example.com/kinetic/node.vwf.yaml
+++ b/support/proxy/vwf.example.com/kinetic/node.vwf.yaml
@@ -44,20 +44,10 @@ methods:
   toggleListening:
 events:
   pointerMove:
-  pointerOut:
-  pointerEnter:
-  pointerLeave:
   pointerDown:
   pointerUp:
   pointerClick:
-  pointerDoubleClick:
-  touchStart:
-  touchMove:
-  touchEnd:
-  tap:
   doubleTap:
-  dragStart:
-  dragMove:
   dragEnd:
   draggingFromView:
 scripts:


### PR DESCRIPTION
This commit introduces an "on" function on the konva view driver that allows that app view to subscribe to view-side UI events.  For now the only events supported are:
- pointerClick
- pointerDoubleClick
- tap
- tapHold
- swipe

(which are the only UI events that we use in our app)

I think that you will find that bringing up the unit editor via double-click is much more consistent now.

We still are getting reflector traffic from other events that we don't listen for, so I plan on rewiring other events in a future PR.

There is a corresponding app branch by the same name.

@youngca @AmbientOSX @landersk61 @davideaster @longtinm would you mind testing/reviewing both branches?
