### PR TITLE
Send an error response for upload errors

### DIFF
--- a/lib/nodejs/stream.js
+++ b/lib/nodejs/stream.js
@@ -55,7 +55,7 @@ function OnStreamRequest( request, response, parsedRequest, segments ) {
 
 function HandlePersistenceUpload( request, response, parsedRequest, segments ) {
     if ( segments.length >= 2 ) {
-        var streamUrl;
+        var streamPath;
         var form = new formidable.IncomingForm();
         form.keepExtensions = true;
         // create the path in file system if not there
@@ -64,11 +64,7 @@ function HandlePersistenceUpload( request, response, parsedRequest, segments ) {
             var relPath = helpers.JoinPath( relPath, segments[i] );
         }
         CreateDirectory( relPath );
-        form.on('error', function(err) {
-            console.log("Error parsing file" + err);
-            throw err
-            return false;
-        }).on('fileBegin', function(name, file) {
+        form.on('fileBegin', function(name, file) {
             // redirect file to the specified path
             var filename = file.name.replace(/\s+/g, '_');
             file.path = helpers.JoinPath( './documents', relPath, filename);
@@ -76,8 +72,14 @@ function HandlePersistenceUpload( request, response, parsedRequest, segments ) {
         });
         // parse the file and then send response
         form.parse(request, function(err, fields, files) {
-            response.writeHead(200, {'content-type': 'text/plain'});
-            response.end(streamPath);
+            if ( ! err ) {
+                response.writeHead(200, {'content-type': 'text/plain'});
+                response.end(streamPath);
+            } else {
+                console.log("Error parsing file: " + err);
+                response.writeHead(500);
+                response.end();
+            }
         });
         return true;
     }


### PR DESCRIPTION
This fixes the server crash during file uploads.

There doesn't appear to be a client problem. The client performing the upload and other clients in the session continue to respond to application events while the upload is in process.

The issue also isn't related specifically to file size, although the lack of a progress indicator would lead the user to cancel and restart the upload for larger files.

When an upload is canceled, the client doesn't stop the active network request. If the user restarts the upload, two overlapping requests will be active. The first one will complete successfully. For reasons I haven't determined yet, the server sees the second request aborted at approximately the same time that it should have completed.

The server error can also be triggered by two separate clients uploading the same file at the same time.

Uploading files using `curl` does not cause the error. Something about the browser upload seems to cause the abort.

The server previously responded to the abort by throwing an exception. Since the call stack is rooted at the network event, this would crash the server. This change returns an error response to the client instead.

@youngca @landersk61 
