### PR TITLE
Send responses for persistence POST requests

### DIFF
--- a/lib/nodejs/persistence.js
+++ b/lib/nodejs/persistence.js
@@ -252,6 +252,8 @@ function HandlePersistenceSave( request, response, parsedRequest, segments ) {
         if ( typeof request.body === "object" ) {
             fs.writeFileSync( helpers.JoinPath( './documents', parsedRequest[ 'public_path' ], saveName, 'saveState' + request.body[ "extension" ] ), request.body[ "jsonState" ] );
             fs.writeFileSync( helpers.JoinPath( './documents', parsedRequest[ 'public_path' ], saveName, 'saveState_' + saveRevision + request.body[ "extension" ] ), request.body[ "jsonState" ] );
+            response.writeHead( 200 );
+            response.end();
         } else {
             request.on( 'data', function ( data ) {
                 persistenceData += data;
@@ -266,6 +268,8 @@ function HandlePersistenceSave( request, response, parsedRequest, segments ) {
                     var processedPost = querystring.parse( persistenceData );
                     fs.writeFileSync( helpers.JoinPath( './documents', parsedRequest[ 'public_path' ], saveName, 'saveState' + processedPost[ "extension" ] ), processedPost[ "jsonState" ] );
                     fs.writeFileSync( helpers.JoinPath( './documents', parsedRequest[ 'public_path' ], saveName, 'saveState_' + saveRevision + processedPost[ "extension" ] ), processedPost[ "jsonState" ] );
+                    response.writeHead( 200 );
+                    response.end();
                 }
             } );
         }
@@ -313,6 +317,7 @@ function Serve( request, response, parsedRequest ) {
                     if ( ( request.method == "POST" ) && ( segments.length > 1 ) ) {
                         return HandlePersistenceSave( request, response, parsedRequest, segments );
                     }
+                    return false;
             }
         }
     }


### PR DESCRIPTION
Otherwise, the client doesn't receive completion status and may block new
requests until the pending requests time out.

@eric79 
