### PR TITLE
Reflector timestamps

### DIFF
--- a/lib/nodejs/reflector.js
+++ b/lib/nodejs/reflector.js
@@ -110,6 +110,7 @@ function OnConnection( socket ) {
             }
         };
         global.instances[ namespace ].setTime( 0.0 );
+
         if ( saveObject ) {
             if ( saveObject[ "queue" ] ) {
                 if ( saveObject[ "queue" ][ "time" ] ) {
@@ -186,13 +187,6 @@ function OnConnection( socket ) {
     //Get the descriptor for the `clients.vwf` child.
     var clientDescriptor = GetClientDescriptor( socket );
 
-    //Create a child in the application's 'clients.vwf' global to represent this client.
-    var clientNodeMessage = {
-        action: "createChild",
-        parameters: [ "http://vwf.example.com/clients.vwf", socket.id, clientDescriptor ],
-        time: global.instances[ namespace ].getTime( )
-    };
-
     // The time for the setState message should be the time the new client joins, so save that time
     var setStateTime = global.instances[ namespace ].getTime( );
 
@@ -226,7 +220,7 @@ function OnConnection( socket ) {
                 time: global.instances[ namespace ].getTime( )
             } );
         }
-        socket.emit( 'message',  clientNodeMessage );
+
         socket.pending = false;
 
         xapi.logClient( saveObject, loadInfo[ 'application_path' ], loadInfo[ 'save_name' ], namespace, clientDescriptor.properties || {}, true, true );
@@ -245,17 +239,25 @@ function OnConnection( socket ) {
         }
         socket.pending = true;
 
-        // Send messages to all the existing clients (that are not pending),
-        // telling them to create a new node under the "clients" parent for the new client
-        for ( var i in global.instances[ namespace ].clients ) {
-            var client = global.instances[ namespace ].clients[ i ];
-            if ( !client.pending ) {
-                client.emit ( 'message',  clientNodeMessage );
-            }
+    }
+
+    //Create a child in the application's 'clients.vwf' global to represent this client.
+    var clientNodeMessage = {
+        action: "createChild",
+        parameters: [ "http://vwf.example.com/clients.vwf", socket.id, clientDescriptor ],
+        time: global.instances[ namespace ].getTime( )
+    };
+
+    // Send messages to all the existing clients (that are not pending),
+    // telling them to create a new node under the "clients" parent for the new client
+    for ( var i in global.instances[ namespace ].clients ) {
+        var client = global.instances[ namespace ].clients[ i ];
+        if ( !client.pending ) {
+            client.emit ( 'message',  clientNodeMessage );
         }
-        if ( global.instances[ namespace ].pendingList.pending ) {
-            global.instances[ namespace ].pendingList.push( clientNodeMessage );
-        }
+    }
+    if ( global.instances[ namespace ].pendingList.pending ) {
+        global.instances[ namespace ].pendingList.push( clientNodeMessage );
     }
 
     socket.on( 'message', function ( msg ) {

--- a/lib/nodejs/reflector.js
+++ b/lib/nodejs/reflector.js
@@ -308,6 +308,8 @@ function OnConnection( socket ) {
                 }
             }
 
+            global.instances[ namespace ].pendingList = [ ];
+
         } else if ( message.action === "execute" ) {
 
             var evaluation = socket.pendingEvaluations && socket.pendingEvaluations.shift();
@@ -316,10 +318,6 @@ function OnConnection( socket ) {
                 evaluation.resolve( message.result );
             }
 
-        }
-
-        if ( message.action == "getState" ) {
-            global.instances[ namespace ].pendingList = [ ];
         }
 
     } );

--- a/lib/nodejs/reflector.js
+++ b/lib/nodejs/reflector.js
@@ -284,6 +284,10 @@ function OnConnection( socket ) {
                 }
             }
 
+            if ( global.instances[ namespace ].pendingList.pending ) {
+                global.instances[ namespace ].pendingList.push( message );
+            }
+
         } else if ( message.action == "getState" ) {
 
             //distribute message to all clients on given instance
@@ -316,8 +320,6 @@ function OnConnection( socket ) {
 
         if ( message.action == "getState" ) {
             global.instances[ namespace ].pendingList = [ ];
-        } else if ( global.instances[ namespace ].pendingList.pending ) {
-            global.instances[ namespace ].pendingList.push( message );
         }
 
     } );


### PR DESCRIPTION
This change sets the time of the `clients.vwf` `createChild` action correctly to be >= the time of the preceding `setState` action. Previously, the timestamps were snapped in the reverse order which could cause the client to execute them backwards and prevent the client from launching correctly.

This change also fixes two problems with recording actions while new clients are pending and clearing the pending list.

@youngca @eric79 
