### PR TITLE
Redirect to the original location after login

### DIFF
--- a/lib/nodejs/authentication.js
+++ b/lib/nodejs/authentication.js
@@ -135,8 +135,8 @@ router.post( "/logout", function( req, res ) {
 router.use( function( req, res, next ) {
   if ( req.isUnauthenticated() ) {
     if ( req.accepts( "html", "json" ) === "html" ) {
-      res.redirect( req.baseUrl + "/login" );
       req.session.returnTo = req.baseUrl + req.url;
+      res.redirect( req.baseUrl + "/login" );
     } else {
       res.sendStatus( 401 );
     }

--- a/lib/nodejs/lobby.js
+++ b/lib/nodejs/lobby.js
@@ -30,6 +30,7 @@ app.use( cookieSession( { secret: sessionSecret() } ) );
 app.use( flash() );
 app.use( "/bootstrap", express.static( "node_modules/bootstrap/dist" ) );
 app.use( "/jquery", express.static( "node_modules/jquery/dist" ) );
+app.use( "/layout.css", express.static( "public/layout.css" ) );
 app.use( authentication );
 
 app.use( function( req, res, next ) {


### PR DESCRIPTION
After intercepting a request from an unauthenticated user and accepting the login, redirect to the originally-requested location.

`res.redirect` sends the response immediately, so the return location must be set in the (cookie-based) session before ending the response. The views' `layout.css` must also be exempted from the login requirement.

@youngca @eric79 