### PR TITLE
Submit on enter

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -21,10 +21,11 @@ block scenarios
     tbody
       if user.instructor
         tr.application
-          td.col-sm-5.title: input.form-control.input-sm(name="title" type="text" placeholder="New Scenario Title")
-          td.col-sm-3.name(colspan=3): input.form-control.input-sm.hidden(name="name" type="text" placeholder="Scenario Name")
-          td.col-sm-3 &nbsp;
-          td.col-sm-1: button.btn.btn-sm.create(disabled) Create
+          form
+            td.col-sm-5.title: input.form-control.input-sm(name="title" type="text" placeholder="New Scenario Title")
+            td.col-sm-3.name(colspan=3): input.form-control.input-sm.hidden(name="name" type="text" placeholder="Scenario Name")
+            td.col-sm-3 &nbsp;
+            td.col-sm-1: button.btn.btn-sm.create(type="submit" disabled) Create
       each scenario_session in scenario_sessions
         -
           var scenario = scenario_session.scenario,
@@ -42,14 +43,15 @@ block scenarios
               td.col-sm-1: a.btn.btn-sm.join(href=session.instance||session.document.uri target="_blank")= session.instance ? "Join" : "Start"
         else if user.instructor
           tr.scenario
-            td.col-sm-5= scenario.state.scenarioTitle
-            td.col-sm-1.company: input.form-control.input-sm(name="company" type="text" maxlength="8")
-            td.col-sm-1.platoon: input.form-control.input-sm(name="platoon" type="number" min="1" max="9" step="1")
-            td.col-sm-1.unit: input.form-control.input-sm(name="unit" type="number" min="1" max="9" step="1")
-            td.col-sm-3.name: input(name="name" type="hidden" value=scenario.state.scenarioName)
-            td.col-sm-1
-              a.btn.btn-sm.edit(href=scenario.instance||scenario.document.uri target="_blank") Edit
-              button.btn.btn-sm.create.hidden(disabled) Create
+            form
+              td.col-sm-5= scenario.state.scenarioTitle
+              td.col-sm-1.company: input.form-control.input-sm(name="company" type="text" maxlength="8")
+              td.col-sm-1.platoon: input.form-control.input-sm(name="platoon" type="number" min="1" max="9" step="1")
+              td.col-sm-1.unit: input.form-control.input-sm(name="unit" type="number" min="1" max="9" step="1")
+              td.col-sm-3.name: input(name="name" type="hidden" value=scenario.state.scenarioName)
+              td.col-sm-1
+                a.btn.btn-sm.edit(href=scenario.instance||scenario.document.uri target="_blank") Edit
+                button.btn.btn-sm.create.hidden(type="submit" disabled) Create
     script.
       document.addEventListener( "DOMContentLoaded", function() {
         $( "table#scenarios" ).on( "input", "tr.scenario", function() {
@@ -66,7 +68,7 @@ block scenarios
             this$.find( ".btn.create" ).prop( "disabled", true );
           }
         } );
-        $( "table#scenarios" ).on( "click", "tr.scenario .btn.create", function() {
+        $( "table#scenarios" ).on( "submit", "tr.scenario form", function() {
           var row$ = $( this ).parents( "tr.scenario" ), properties = {
                name: row$.find( ".name input" ).val(),
             company: row$.find( ".company input" ).val(),
@@ -76,6 +78,7 @@ block scenarios
           $.post( "sessions", properties ).
             done( function() { document.location.reload() } ).
             fail( function() {} );
+          return false;
         } );
         $( "table#scenarios" ).on( "input", "tr.application", function() {
           var this$ = $( this ),
@@ -87,7 +90,7 @@ block scenarios
             this$.find( ".btn.create" ).prop( "disabled", true );
           }
         } );
-        $( "table#scenarios" ).on( "click", "tr.application .btn.create", function() {
+        $( "table#scenarios" ).on( "submit", "tr.application form", function() {
           var row$ = $( this ).parents( "tr.application" ), properties = {
              name: row$.find( ".name input" ).val(),
             title: row$.find( ".title input" ).val(),
@@ -95,6 +98,7 @@ block scenarios
           $.post( "scenarios", properties ).
             done( function() { document.location.reload() } ).
             fail( function() {} );
+          return false;
         } );
       } );
 

--- a/views/index.jade
+++ b/views/index.jade
@@ -24,7 +24,7 @@ block scenarios
           td.col-sm-5.title: input.form-control.input-sm(name="title" type="text" placeholder="New Scenario Title")
           td.col-sm-3.name(colspan=3): input.form-control.input-sm.hidden(name="name" type="text" placeholder="Scenario Name")
           td.col-sm-3 &nbsp;
-          td.col-sm-1: button.btn.btn-sm.create(disabled="disabled") Create
+          td.col-sm-1: button.btn.btn-sm.create(disabled) Create
       each scenario_session in scenario_sessions
         -
           var scenario = scenario_session.scenario,
@@ -49,7 +49,7 @@ block scenarios
             td.col-sm-3.name: input(name="name" type="hidden" value=scenario.state.scenarioName)
             td.col-sm-1
               a.btn.btn-sm.edit(href=scenario.instance||scenario.document.uri target="_blank") Edit
-              button.btn.btn-sm.create.hidden Create
+              button.btn.btn-sm.create.hidden(disabled) Create
     script.
       document.addEventListener( "DOMContentLoaded", function() {
         $( "table#scenarios" ).on( "input", "tr.scenario", function() {
@@ -59,9 +59,11 @@ block scenarios
           if ( filled ) {
             this$.find( ".btn.edit" ).addClass( "hidden" );
             this$.find( ".btn.create" ).removeClass( "hidden" );
+            this$.find( ".btn.create" ).prop( "disabled", false );
           } else {
             this$.find( ".btn.edit" ).removeClass( "hidden" );
             this$.find( ".btn.create" ).addClass( "hidden" );
+            this$.find( ".btn.create" ).prop( "disabled", true );
           }
         } );
         $( "table#scenarios" ).on( "click", "tr.scenario .btn.create", function() {
@@ -79,10 +81,10 @@ block scenarios
           var this$ = $( this ),
             filled = this$.find( ".title input" ).val();
           if ( filled ) {
-            this$.find( ".btn.create" ).removeAttr( 'disabled' );
+            this$.find( ".btn.create" ).prop( "disabled", false );
             this$.find( ".name input" ).val( this$.find( ".title input" ).val().replace( /[^0-9A-Za-z]+/g, "-" ) );
           } else {
-            this$.find( ".btn.create" ).add( 'disabled', '"disabled"' );
+            this$.find( ".btn.create" ).prop( "disabled", true );
           }
         } );
         $( "table#scenarios" ).on( "click", "tr.application .btn.create", function() {


### PR DESCRIPTION
Submit new-scenario and new-session requests using the Enter key in addition to the Create button.

This change wraps a form around the input field and button and catches the form's `submit` event instead of the button's `click` event to make the request.

@youngca @eric79
