### PR TITLE
Feature/core tests

### DIFF
--- a/support/client/lib/vwf/view/kineticjs.js
+++ b/support/client/lib/vwf/view/kineticjs.js
@@ -1033,19 +1033,15 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
             if ( viewDriver && viewDriver.state.nodes[ pointerPickID ] ) {
                 var childID = pointerPickID;
                 var child = viewDriver.state.nodes[ childID ];
-                var parentID = child.parentID;
-                var parent = viewDriver.state.nodes[ child.parentID ];
                 while ( child ) {
 
                     returnData.eventNodeData[ childID ] = [ {
                         pickID: pointerPickID,
                     } ];
 
-                    childID = parentID;
+                    // Line up the next "child" up the hierarchy
+                    childID = child.parentID;
                     child = viewDriver.state.nodes[ childID ];
-                    parentID = child ? child.parentID : undefined;
-                    parent = parentID ? viewDriver.state.nodes[ child.parentID ] : undefined;
-
                 }
             }
         }

--- a/support/client/lib/vwf/view/mocha.js
+++ b/support/client/lib/vwf/view/mocha.js
@@ -12,8 +12,8 @@
 /// @requires vwf/view
 
 define( [
-    "module", "vwf/view", "jquery", "vwf/view/mocha/mocha", "vwf/view/chai/chai"
-], function( module, view, $, mocha, chai ) {
+    "module", "vwf/view", "jquery", "vwf/view/mocha/mocha", "vwf/view/chai/chai", "test/index"
+], function( module, view, $, mocha, chai, test ) {
 
     // vwf/view/mocha.js is a driver used for unit tests based on mocha + chai.
 
@@ -33,12 +33,14 @@ define( [
             $( "body" )
                 .append( "<link rel='stylesheet' href='vwf/view/mocha/mocha.css'>" )
                 .append( "<div id='mocha'></div>" );
-
-            // Load the test file and run it
-            require( [ "test/index" ], function() {
-                mocha.run();
-            } );
         },
+
+        initializedNode: function( nodeID, childID ) {
+            if ( childID === vwf_view.kernel.application() ) {
+                test();
+                mocha.run();
+            }
+        }
 
     } );
 


### PR DESCRIPTION
Moves the point at which tests are run into `initializedNode` to ensure that all js files (those being tested) are loaded before the tests are run.

This corresponds to the app-side branch `tdg-core-refactor`

@davideaster @youngca @landersk61 @AmbientOSX @longtinm 