### PR TITLE
Add favicon as a static asset as a workaround for redirect bug

### DIFF
--- a/lib/nodejs/lobby.js
+++ b/lib/nodejs/lobby.js
@@ -31,6 +31,7 @@ app.use( flash() );
 app.use( "/bootstrap", express.static( "node_modules/bootstrap/dist" ) );
 app.use( "/jquery", express.static( "node_modules/jquery/dist" ) );
 app.use( "/layout.css", express.static( "public/layout.css" ) );
+app.use( "/favicon.ico", express.static( "public/favicon.ico" ) ); 
 app.use( authentication );
 
 app.use( function( req, res, next ) {


### PR DESCRIPTION
@landersk61 would you mind testing this on one of the test suite machines (which hasn't yet experienced the giant unit symbol) to see if this avoids the giant unit symbol issue?