### PR TITLE
Remove dependency on Chrome-only TouchEvent type

### DIFF
--- a/support/client/lib/vwf/view/kineticjs.js
+++ b/support/client/lib/vwf/view/kineticjs.js
@@ -999,7 +999,7 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
             e.evt.stopPropagation && e.evt.stopPropagation();
         }
 
-        var isTouchEvent = ( e.evt instanceof TouchEvent );
+        var isTouchEvent = !!e.evt.touches;
         var eventPosition = isTouchEvent ? e.evt.changedTouches[ 0 ] : e.evt;
 
         var stage = node && node.stage;


### PR DESCRIPTION
This removes the only known impediment to using ITDG in Firefox.  We will need to do a full-up test before we can for sure claim Firefox support, but this might get us there.

@youngca @longtinm @landersk61 