### PR TITLE
Handle case where there are no supporting files in a scenario

### DIFF
--- a/lib/nodejs/lobby.js
+++ b/lib/nodejs/lobby.js
@@ -118,9 +118,7 @@ app.get( "/export-scenarios", function( req, res ) {
       .then( jsonBuffer => {
         var filePathRegex = /"stream\/documents\/ITDG\/[^"]*"/g;
         var dependencyFilePaths =
-          jsonBuffer
-            .toString()
-            .match( filePathRegex )
+          ( jsonBuffer.toString().match( filePathRegex ) || [] )
             .map( match => match.slice( 1, -1 ).replace( "stream/", "" ) );
         var fileExtensionRegex = /\.[^\.]*$/;
         var tifDependencyFilePaths =


### PR DESCRIPTION
Old scenarios don't follow the convention where supporting file urls start with `stream/documents/`.  In that case, they will not be identified by the export.  Previously, this would cause an uncaught `TypeError` ... now it will just export the scenario without its supporting files.

We assume that all our users' scenarios are new enough to not run into this issue.