### PR TITLE
Make units scalable

### DIFF
--- a/support/client/lib/vwf/view/kineticjs.js
+++ b/support/client/lib/vwf/view/kineticjs.js
@@ -943,7 +943,12 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
                         // having the model set the view back to an old value, which results in 
                         // jitter while the user is dragging the node)
                         viewDriver.kernel.fireEvent( nodeID, "draggingFromView" );
-                        viewDriver.kernel.setProperty( nodeID, "position", [ kineticX, kineticY ] );
+                        viewDriver.kernel.callMethod( nodeID, "setMapPositionFromPosition", [ 
+                            {
+                                x: kineticX,
+                                y: kineticY
+                            }
+                        ] );
 
                         doRenderNodes = true;
                         renderNodes[ nodeID ] = kineticObj;

--- a/support/proxy/vwf.example.com/kinetic/node.vwf.yaml
+++ b/support/proxy/vwf.example.com/kinetic/node.vwf.yaml
@@ -36,7 +36,6 @@ properties:
   modelY:
   supportMouseAndTouchEvents: false
   hasMouseAndTouchEvents: false
-  dragProperty: "position"
   attributes:
 methods:
   toggleVisibility:

--- a/support/proxy/vwf.example.com/mil-sym/unitGroup.js
+++ b/support/proxy/vwf.example.com/mil-sym/unitGroup.js
@@ -150,14 +150,28 @@ this.updateThreatShape = function() {
 
 }
 
-this.setAbsoluteMapPosition = function( mapPosition ) {
-  if ( mapPosition !== undefined ) {
-    this.mapPosition = mapPosition;
+this.setPositionFromMapPosition = function() {
+    var symbolCenter = ( this.icon || {} ).symbolCenter || {
+        x: 0,
+        y: 0
+    }
     this.position = {
-      "x": this.mapPosition.x,
-      "y": this.mapPosition.y
+        x: this.mapPosition.x - this.scaleX * symbolCenter.x,
+        y: this.mapPosition.y - this.scaleY * symbolCenter.y
     };
-  }
+}
+
+this.setMapPositionFromPosition = function( konvaObjectPosition ) {
+    var symbolCenter = ( this.icon || {} ).symbolCenter || {
+        x: 0,
+        y: 0
+    };
+    this.mapPosition = {
+        x: konvaObjectPosition.x + this.scaleX * symbolCenter.x,
+        y: konvaObjectPosition.y + this.scaleY * symbolCenter.y,
+    }
+
+    //# sourceURL=unitGroup.setMapPositionFromPosition
 }
 
 //# sourceURL=unitGroup.js

--- a/support/proxy/vwf.example.com/mil-sym/unitGroup.vwf.yaml
+++ b/support/proxy/vwf.example.com/mil-sym/unitGroup.vwf.yaml
@@ -2,10 +2,10 @@
 extends: http://vwf.example.com/kinetic/group.vwf
 properties: 
   supportMouseAndTouchEvents: true
+  disableScaleAndRotationForSpeed: false
   index: 8
   zIndex: 8
   dragToTop: true
-  transformsEnabled: "position"
   mapPosition:
     set: |
       if ( value !== undefined ) {

--- a/support/proxy/vwf.example.com/mil-sym/unitGroup.vwf.yaml
+++ b/support/proxy/vwf.example.com/mil-sym/unitGroup.vwf.yaml
@@ -10,14 +10,7 @@ properties:
     set: |
       if ( value !== undefined ) {
         this.mapPosition = value;
-        if ( this.icon && this.icon.symbolCenter ) {
-          this.position = {
-            "x": ( this.mapPosition.absolute ? this.mapPosition.x : this.mapPosition.x - this.icon.symbolCenter.x ),
-            "y": ( this.mapPosition.absolute ? this.mapPosition.y : this.mapPosition.y - this.icon.symbolCenter.y )
-          };
-        } else {
-          this.position = { "x": value.x, "y": value.y };
-        } 
+        this.setPositionFromMapPosition();
       }
     value: { "x": 0, "y": 0 }
 
@@ -44,11 +37,11 @@ properties:
   mirrorAll: false
 methods:
   updateThreatShape:
-
   handleRender:
-
+  setPositionFromMapPosition:
+  setMapPositionFromPosition:
 events:
   threatShapeChanged:
-  
+  unitGroupDragged:
 scripts:
 - source: "unitGroup.js"

--- a/support/proxy/vwf.example.com/mil-sym/unitIcon.js
+++ b/support/proxy/vwf.example.com/mil-sym/unitIcon.js
@@ -2,17 +2,7 @@ this.initialize = function() {
 
     if ( this.imageGenerator !== undefined ) {
         this.imageGenerator.imageRendered = this.events.add( function( img, iconSize, symbolCenter, symbolBounds ) {
-            
-            var mp = this.parent.mapPosition;
-
-            this.image = img;
-            this.size = iconSize;
-            this.width = iconSize.width;
-            this.height = iconSize.height;
-            this.symbolCenter = symbolCenter;
-
-            this.parent.mapPosition = mp;
-            
+            this.updateIcon( img, iconSize, symbolCenter );
         }, this );
     }
 
@@ -20,18 +10,25 @@ this.initialize = function() {
 
 this.handleRender = function( img, iconSize, symbolCenter, symbolBounds ){
 
-    var mp = this.parent.mapPosition;
+    this.updateIcon( img, iconSize, symbolCenter );
 
+    if ( this.parent !== undefined ) {
+        this.parent.handleRender( img, iconSize, symbolCenter, symbolBounds );
+    }
+}
+
+this.updateIcon = function( img, iconSize, symbolCenter ) {
+
+    // Update the image to the one that has just been rendered
     this.image = img;
     this.size = iconSize;
     this.width = iconSize.width;
     this.height = iconSize.height;
     this.symbolCenter = symbolCenter;
 
-    this.parent.mapPosition = mp;
-
-    if ( this.parent !== undefined ) {
-        this.parent.handleRender( img, iconSize, symbolCenter, symbolBounds );
-    }
+    // Since the size of the icon might have changed,
+    // reset the unit group's "position" (upper left point)
+    // to keep its center on "mapPosition" 
+    this.parent.setPositionFromMapPosition();
 }
 //# sourceURL=unitIcon.js

--- a/support/proxy/vwf.example.com/mil-sym/unitIcon.vwf.yaml
+++ b/support/proxy/vwf.example.com/mil-sym/unitIcon.vwf.yaml
@@ -29,6 +29,10 @@ properties:
   transformsEnabled: "position"
   zIndex: 20
 
+methods:
+  handleRender:
+  updateIcon:
+
 events:
 
   imageChanged:
@@ -36,10 +40,6 @@ events:
   iconSizeChanged:
 
   symbolCenterChanged:
-
-methods:
-
-  handleRender:
 
 scripts:
 - source: "unitIcon.js"


### PR DESCRIPTION
Allow units to be scaled (so we can apply a counter-scale when the user zooms the map).  This will incur a minor performance penalty as the konva renderer will no longer be able to skip the "scale and rotate" calculation for units.  But I don't imagine that the performance hit will be too substantial.