### PR TITLE
Account for scale when updating unit position in model

### DIFF
--- a/support/client/lib/vwf/view/kineticjs.js
+++ b/support/client/lib/vwf/view/kineticjs.js
@@ -935,20 +935,22 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
 
                     // If the position of this node has changed since its last model value, set the
                     // model property with the new value
-                    if ( ( positionProperty.value[0] !== kineticX ) || 
-                         ( positionProperty.value[1] !== kineticY ) ) {
+                    if ( ( positionProperty.value.x !== kineticX ) || 
+                         ( positionProperty.value.y !== kineticY ) ) {
 
                         // Fire this event to notify the model that kinetic has already updated the
                         // view and it doesn't need to (if the model set the value, it would risk 
                         // having the model set the view back to an old value, which results in 
                         // jitter while the user is dragging the node)
                         viewDriver.kernel.fireEvent( nodeID, "draggingFromView" );
-                        viewDriver.kernel.callMethod( nodeID, "setMapPositionFromPosition", [ 
-                            {
-                                x: kineticX,
-                                y: kineticY
-                            }
-                        ] );
+                        viewDriver.kernel.callMethod( nodeID, "setMapPositionFromPosition",
+                            [ 
+                                {
+                                    x: kineticX,
+                                    y: kineticY
+                                },
+                                kineticObj.scaleX()
+                            ] );
 
                         doRenderNodes = true;
                         renderNodes[ nodeID ] = kineticObj;

--- a/support/proxy/vwf.example.com/mil-sym/unitGroup.js
+++ b/support/proxy/vwf.example.com/mil-sym/unitGroup.js
@@ -161,14 +161,14 @@ this.setPositionFromMapPosition = function() {
     };
 }
 
-this.setMapPositionFromPosition = function( konvaObjectPosition ) {
+this.setMapPositionFromPosition = function( konvaObjectPosition, scale ) {
     var symbolCenter = ( this.icon || {} ).symbolCenter || {
         x: 0,
         y: 0
     };
     this.mapPosition = {
-        x: konvaObjectPosition.x + this.scaleX * symbolCenter.x,
-        y: konvaObjectPosition.y + this.scaleY * symbolCenter.y,
+        x: konvaObjectPosition.x + scale * symbolCenter.x,
+        y: konvaObjectPosition.y + scale * symbolCenter.y,
     }
 
     //# sourceURL=unitGroup.setMapPositionFromPosition


### PR DESCRIPTION
When calling `setMapPositionFromPosition` I had each client rely on their own scale, rather than use the scale from the client whose position was being used for the update.  This fixes that.

Edit: @longtinm , in case you saw my previous message about updating the function, name, I put it back the way that it was because I thought it ill-advised for me to break compatibility with your app right before a big release.  ;o)