### PR TITLE
Unstick `mouseDown`

### DIFF
--- a/support/client/lib/vwf/view/kineticjs.js
+++ b/support/client/lib/vwf/view/kineticjs.js
@@ -208,6 +208,9 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
         } );
 
         node.kineticObj.on( "mouseenter", function( evt ) {
+            // Correct `mouseDown` if the button changed outside any node with an active "on mouseup"
+            mouseDown = !!( evt.evt.buttons & 1 );
+
             var eData = processEvent( evt, node, false );
 
             if ( mouseDown || ( evt.evt.buttons ) ) {


### PR DESCRIPTION
Konva `mousedown`/`mouseup` listeners are frequently only active on a subset of the nodes and not across the entire canvas. If the mouse button is pressed while over a node with an active `mousedown` listener and released outside of any node without an active `mouseup` listener, we never see a `mouseup` event and the `mouseDown` variable remains set.

Since `mouseDown` indicates that enter and exit events should become swipe events, this causes spurious swipe events as the mouse is moved across the drawing.

@youngca @landersk61 