### PR TITLE
Catch nonexistent files

### DIFF
--- a/lib/nodejs/stream.js
+++ b/lib/nodejs/stream.js
@@ -16,9 +16,17 @@ function OnStreamRequest( request, response, parsedRequest, segments ) {
         }
         var m = mime.lookup( file );
         if ( m.substring( 0, 5 ) ===  "image" ) {
-            var img = fs.readFileSync(file);
-            response.writeHead(200, {'Content-Type': m });
-            response.end(img, 'binary');
+            try {
+                var img = fs.readFileSync( file );
+                response.writeHead( 200, { 'Content-Type': m } );
+                response.end(img, 'binary');
+            } catch (err) {
+                if ( err.code === "ENOENT" ) {
+                    response.status( 404 ).send( file + " not found" );
+                } else {
+                    throw err;
+                }
+            }
         } else {
             var range = request.headers.range || "bytes=0-";
             if ( range ) {

--- a/lib/nodejs/stream.js
+++ b/lib/nodejs/stream.js
@@ -16,17 +16,18 @@ function OnStreamRequest( request, response, parsedRequest, segments ) {
         }
         var m = mime.lookup( file );
         if ( m.substring( 0, 5 ) ===  "image" ) {
-            try {
-                var img = fs.readFileSync( file );
-                response.writeHead( 200, { 'Content-Type': m } );
-                response.end(img, 'binary');
-            } catch (err) {
-                if ( err.code === "ENOENT" ) {
-                    response.status( 404 ).send( file + " not found" );
+            fs.readFile( file, ( err, img ) => {
+                if ( err ) {
+                    if ( err.code === "ENOENT" ) {
+                        response.status( 404 ).send( file + " not found" );
+                    } else {
+                        throw err;
+                    }
                 } else {
-                    throw err;
+                    response.writeHead( 200, { 'Content-Type': m } );
+                    response.end( img, 'binary' );
                 }
-            }
+            } );
         } else {
             var range = request.headers.range || "bytes=0-";
             if ( range ) {


### PR DESCRIPTION
This catches cases where the client makes a request for a non-existent file (which newly is an issue since the map tile functionality can request tiles that we don't have images for).

In the process, I made the file reading asynchronous, which might improve performance a little bit, especially as we add clients that might all make requests of the server at the same time.