### PR TITLE
When an image loads, resize the konva object to match the new image

### DIFF
--- a/support/client/lib/vwf/model/kineticjs.js
+++ b/support/client/lib/vwf/model/kineticjs.js
@@ -2152,6 +2152,9 @@ define( [ "module",
                 } else {
                     kineticObj.scale( { "x": height / imageObj.height ,"y": height / imageObj.height } );
                 }
+            } else {
+                kineticObj.width( imageObj.width );
+                kineticObj.height( imageObj.height );
             }
 
             // Redraw the object now that it's image has loaded


### PR DESCRIPTION
I'll admit that there is a little bit of voodoo going on here.  It appears that konva images were already automatically updating on load until I manually changed the width/height of the object.  After that, new images did not update the konva object.  I'm not sure what the mechanism is that causes that kind of behavior, but that's what I was seeing.

Context: The map's konva image object width and height is used to determine the minimum zoom level that will keep the map filling the screen (at least in one dimension).  To achieve the same effect for the tile sets (which don't have a static map), I manually set the height/width of the hidden static map object to match that of the geotiff file.

I was seeing that after I did that, if I loaded a new static map, it was distorted according to the size that I manually set.