### PR TITLE
Allow test window to scroll

### DIFF
--- a/support/client/lib/vwf/view/mocha.js
+++ b/support/client/lib/vwf/view/mocha.js
@@ -38,7 +38,10 @@ define( [
         initializedNode: function( nodeID, childID ) {
             if ( childID === vwf_view.kernel.application() ) {
                 test();
-                window.runTests = mocha.run;
+                window.runTests = function() {
+                    $( "body" ).css( "overflowY", "scroll" );
+                    mocha.run();
+                };
             }
         }
 


### PR DESCRIPTION
In ordinary usage, a VWF window suppresses scrolling - what you see on the screen is what you get.

But when we're viewing test output, the test results can overflow off the bottom of the screen.  This change enables the scroll bar when we run tests.

And yes, it's still weird that the test results print out inside a VWF app.  We can improve that in the future.  :smile: 