### PR TITLE
Do not load Google Closure library in base VWF index.html

### DIFF
--- a/support/client/lib/index.html
+++ b/support/client/lib/index.html
@@ -39,11 +39,6 @@
 
     <script type="text/javascript" src="async.js?mtime=timestamp"></script>
 
-    <script type="text/javascript" src="closure/base.js?mtime=timestamp"></script>
-    <script type="text/javascript">goog.require('goog.vec.Vec2')</script>
-    <script type="text/javascript">goog.require('goog.vec.Mat4')</script>
-    <script type="text/javascript">goog.require('goog.vec.Quaternion')</script>
-
     <script type="text/javascript" src="crypto.js?mtime=timestamp"></script>
     <script type="text/javascript" src="md5.js?mtime=timestamp"></script>
 


### PR DESCRIPTION
This library is a bit of a memory hog.  It is used by the three.js, glge, and blockly drivers, none of which are used in the ITDG app.

I figure that if another project would like to use our `tdg` branch, they can devise a better way to load the dependencies that they need.  :smile: 