### PR TITLE
Remove reference to non-existent textValueUpdated event

### DIFF
--- a/support/client/lib/vwf/view/kineticjs.js
+++ b/support/client/lib/vwf/view/kineticjs.js
@@ -776,15 +776,6 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color" ],
                     }
                     break;
 
-                case "textValueUpdated":
-                    if ( isDrawingObject( eventData[ 0 ] ) ) {
-                        var drawingObject = drawing_private.drawingObject;
-                        drawingObject.text( eventData[ 1 ] );
-                        drawObject( drawingObject, true );
-                        propagateNodeToModel( drawing_private );
-                    }
-                    break;
-
                 default:
                     break;
             }


### PR DESCRIPTION
The `textValueUpdated` event was not fired anywhere in our code, so I removed this unnecessary handler.