### PR TITLE
Ensure that satProperty is fired for mil-sym modifiers

### DIFF
--- a/support/client/lib/vwf/model/mil-sym.js
+++ b/support/client/lib/vwf/model/mil-sym.js
@@ -465,8 +465,6 @@ define( [ "module",
                                     node.height= attrs.height;
                                     attrs.image = renderMsnGfx( node );
                                     modelDriver.kernel.setProperty( node.ID, propertyName, attrs );
-                                    //renderImage = basicPropertiesMet( node );
-                                    //value = propertyValue;
                                 }
                             }
                             break;
@@ -484,7 +482,16 @@ define( [ "module",
                    
                     // Render image if modifier is valid
                     renderImage = setModifier( unit, propertyName, propertyValue );
-                    
+
+                    // Because rendering the image will set other properties
+                    // (image, height, width, symbolCenter, etc),
+                    // the kernel will interpret modifiers that were set as having been delegated,
+                    // and no satProperty will be issued.
+                    // We force an actual delegation here,
+                    // so the object driver will issue the satProperty.
+                    if ( renderImage ) {
+                        modelDriver.kernel.setProperty( node.ID, propertyName, propertyValue );
+                    }
                 }
             }
 


### PR DESCRIPTION
When a mil-sym modifier is set, it triggers a re-render of the symbol icon, which sets a number of other properties (`image`, `height`, `width`, `symbolCenter`, etc).  VWF interprets this as a "delegation" (when a `setProperty` doesn't actually set a real property, but triggers another to be set instead).  It handles this by letting the real property that is delegated to, issue the `satProperty`.  The original property never gets a `satProperty`.  This was undesired behavior for the setting of the unit modifiers, which aren't true delegations, though setting one causes other properties to be set, too.

This code forces a proper delegation, telling the object driver to set the value of the modifier, which triggers the `satProperty` as desired.