### PR TITLE
When user drags a node, set its mapPosition directly

### DIFF
--- a/support/client/lib/vwf/model/kineticjs.js
+++ b/support/client/lib/vwf/model/kineticjs.js
@@ -783,9 +783,12 @@ define( [ "module",
                             break;
 
                         case "scaleOnLoad":
-                            //node.scaleOnLoad = Boolean( propertyValue );
                             break;
                         
+                        case "symbolCenter":
+                            kineticObj.attrs.symbolCenter = propertyValue;
+                            break;
+
                         default:
                             value = undefined;
                             break;
@@ -1370,9 +1373,11 @@ define( [ "module",
                                 break;
 
                             case "scaleOnLoad":
-                                //value = node.scaleOnLoad;
                                 break;
                             
+                            case "symbolCenter":
+                                value = kineticObj.attrs.symbolCenter;
+                                break;
                         }                    
                     }
 


### PR DESCRIPTION
Previously, it called the setMapPositionFromPosition method, but as a result, external applications receiving reflector traffic were never sent the new mapPosition since that was calculated internally in the model.  This is a little bit hacky as the code in the comment describes, but it's the best option for our use case.

@longtinm, with this change, the only thing that calls the `setMapPositionFromPosition` function is your scenario server.  I think that your intent is to rework that so it sets the `mapPosition` property directly.  If I am correct, then when you have completed that work, we can remove the `setMapPositionFromPosition` method entirely.