### PR TITLE
Eliminate duplicate unit renders

### DIFF
--- a/support/client/lib/mil-sym/cws.js
+++ b/support/client/lib/mil-sym/cws.js
@@ -5353,25 +5353,24 @@ define( function(){
                   "symbolID": "G*FPLCF---****X",
                   "tag": "FIRE SUPPORT COORDINATION LINE",
                   "symbolType": "MultiSegmentLine",
-                  "validModifiers": [ "uniqueDesignation1", "uniqueDesignation2" ]
+                  "validModifiers": [ "uniqueDesignation1" ]
             },
             "TACGRP.FSUPP.LNE.C2LNE.CFL": {
                   "symbolID": "G*FPLCC---****X",
                   "tag": "COORDINATED FIRE LINE",
                   "symbolType": "MultiSegmentLine",
-                  "validModifiers": [ "uniqueDesignation1", "uniqueDesignation2" ]
+                  "validModifiers": [ "uniqueDesignation1" ]
             },
             "TACGRP.FSUPP.LNE.C2LNE.NFL": {
                   "symbolID": "G*FPLCN---****X",
                   "tag": "NO-FIRE LINE",
-                  "symbolType": "MultiSegmentLine",
-                  "validModifiers": [ "uniqueDesignation1", "uniqueDesignation2" ]
+                  "symbolType": "MultiSegmentLine"
             },
             "TACGRP.FSUPP.LNE.C2LNE.RFL": {
                   "symbolID": "G*FPLCR---****X",
                   "tag": "RESTRICTIVE FIRE LINE",
                   "symbolType": "MultiSegmentLine",
-                  "validModifiers": [ "uniqueDesignation1", "uniqueDesignation2" ]
+                  "validModifiers": [ "uniqueDesignation1" ]
             },
             "TACGRP.MOBSU.SU.FTFDLN": {
                   "symbolID": "G*MPSL----****X",
@@ -5783,7 +5782,7 @@ define( function(){
                   "symbolID": "G*GPAAW---****X",
                   "tag": "WEAPONS FREE ZONE",
                   "symbolType": "MultiSegmentPolygon",
-                  "validModifiers": [ "uniqueDesignation1", "additionalInfo1", "additionalInfo2", "DTG1", "DTG2" ]
+                  "validModifiers": [ "uniqueDesignation1", "DTG1", "DTG2" ]
             }
        },
 

--- a/support/client/lib/vwf/model/kineticjs.js
+++ b/support/client/lib/vwf/model/kineticjs.js
@@ -2219,7 +2219,7 @@ define( [ "module",
         }
         imageObj.onerror = function() {
             modelDriver.logger.errorx( "loadImage", "Invalid image url:", url );
-                imageObj.src = oldSrc;
+            imageObj.src = oldSrc;
             modelDriver.kernel.fireEvent( nodeID, "imageLoadError", [ url ] );
         }
 

--- a/support/client/lib/vwf/model/kineticjs.js
+++ b/support/client/lib/vwf/model/kineticjs.js
@@ -1142,143 +1142,140 @@ define( [ "module",
                         return value;
                     }
 
-                    //if ( value === undefined ) {
+                    switch ( propertyName ) {
 
-                        switch ( propertyName ) {
+                        case "x":
+                            value = kineticObj.x() || 0;
+                            break;
 
-                            case "x":
-                                value = kineticObj.x() || 0;
-                                break;
+                        case "y":
+                            value = kineticObj.y() || 0;
+                            break;
 
-                            case "y":
-                                value = kineticObj.y() || 0;
-                                break;
+                        case "width":
+                            value = kineticObj.width();
+                            break;
 
-                            case "width":
-                                value = kineticObj.width();
-                                break;
+                        case "height":
+                            value = kineticObj.height();
+                            break;
 
-                            case "height":
-                                value = kineticObj.height();
-                                break;
+                        case "visible":
+                            value = kineticObj.visible();
+                            break;
 
-                            case "visible":
-                                value = kineticObj.visible();
-                                break;
+                        case "isVisible":
+                            value = kineticObj.isVisible();
+                            break;
 
-                            case "isVisible":
-                                value = kineticObj.isVisible();
-                                break;
+                        case "listening":
+                            value = kineticObj.listening();
+                            break;
+                        
+                        case "isListening":
+                            value = kineticObj.isListening();
+                            break;
+                        
+                        case "opacity":
+                            value = kineticObj.opacity();
+                            break;
 
-                            case "listening":
-                                value = kineticObj.listening();
-                                break;
-                            
-                            case "isListening":
-                                value = kineticObj.isListening();
-                                break;
-                            
-                            case "opacity":
-                                value = kineticObj.opacity();
-                                break;
+                        case "scale":
+                            value = kineticObj.scale();
+                            break;
 
-                            case "scale":
-                                value = kineticObj.scale();
-                                break;
+                        case "scaleX":
+                            value = kineticObj.scaleX();
+                            break;
 
-                            case "scaleX":
-                                value = kineticObj.scaleX();
-                                break;
+                        case "scaleY":
+                            value = kineticObj.scaleY();
+                            break;
 
-                            case "scaleY":
-                                value = kineticObj.scaleY();
-                                break;
+                        case "rotation":
+                            value = kineticObj.rotation();
+                            break;
 
-                            case "rotation":
-                                value = kineticObj.rotation();
-                                break;
+                        // check code, not in docs
+                        case "offset":
+                            value = kineticObj.offset();
+                            break;
 
-                            // check code, not in docs
-                            case "offset":
-                                value = kineticObj.offset();
-                                break;
+                        // check code, not in docs
+                        case "offsetX":
+                            value = kineticObj.offsetX();
+                            break;
 
-                            // check code, not in docs
-                            case "offsetX":
-                                value = kineticObj.offsetX();
-                                break;
+                        case "offsetY":
+                            value = kineticObj.offsetY();
+                            break;
 
-                            case "offsetY":
-                                value = kineticObj.offsetY();
-                                break;
+                        case "draggable":
+                            // Return the model value that we have stored separately, 
+                            // not the value that is directly in the kinetic object 
+                            // because a user's view might have changed that for only 
+                            // that user
+                            value = kineticObj.isDraggable;    
+                            break;
 
-                            case "draggable":
-                                // Return the model value that we have stored separately, 
-                                // not the value that is directly in the kinetic object 
-                                // because a user's view might have changed that for only 
-                                // that user
-                                value = kineticObj.isDraggable;    
-                                break;
+                        // check code, not in docs
+                        case "dragDistance":
+                            value = kineticObj.dragDistance();    
+                            break;
 
-                            // check code, not in docs
-                            case "dragDistance":
-                                value = kineticObj.dragDistance();    
-                                break;
+                        case "zIndex":
+                            value = kineticObj.getZIndex();
+                            break;
 
-                            case "zIndex":
-                                value = kineticObj.getZIndex();
-                                break;
+                        case "dragBoundFunc":
+                            var dragBoundFunc = kineticObj.dragBoundFunc();
+                            value = dragBoundFunc ? dragBoundFunc.toString() : undefined;
+                            break;
 
-                            case "dragBoundFunc":
-                                var dragBoundFunc = kineticObj.dragBoundFunc();
-                                value = dragBoundFunc ? dragBoundFunc.toString() : undefined;
-                                break;
+                        case "id":
+                            value = kineticObj.getId();
+                            break
 
-                            case "id":
-                                value = kineticObj.getId();
-                                break
+                        case "name":
+                            value = kineticObj.getName();
+                            break;
+                        
+                        case "position":
+                            value = {
+                                x: kineticObj.x() || 0,
+                                y: kineticObj.y() || 0
+                            };
+                            break;
 
-                            case "name":
-                                value = kineticObj.getName();
-                                break;
-                            
-                            case "position":
-                                value = {
-                                    x: kineticObj.x() || 0,
-                                    y: kineticObj.y() || 0
-                                };
-                                break;
+                        case "transform":
+                            value = kineticObj.getTransform().m;
+                            break;
 
-                            case "transform":
-                                value = kineticObj.getTransform().m;
-                                break;
+                        case "absolutePosition":
+                                value = kineticObj.getAbsolutePosition();
+                            break;
 
-                            case "absolutePosition":
-                                    value = kineticObj.getAbsolutePosition();
-                                break;
+                        case "absoluteTransform":
+                                value = kineticObj.getAbsoluteTransform();
+                            break;
 
-                            case "absoluteTransform":
-                                    value = kineticObj.getAbsoluteTransform();
-                                break;
+                        case "absoluteOpacity":
+                            value = kineticObj.getAbsoluteOpacity();
+                            break;
 
-                            case "absoluteOpacity":
-                                value = kineticObj.getAbsoluteOpacity();
-                                break;
+                        case "absoluteZIndex":
+                            value = kineticObj.getAbsoluteZIndex();
+                            break;
 
-                            case "absoluteZIndex":
-                                value = kineticObj.getAbsoluteZIndex();
-                                break;
+                        case "hitGraphFromCache":
+                            value = kineticObj.attrs.hitGraphFromCache;
+                            break;
 
-                            case "hitGraphFromCache":
-                                value = kineticObj.attrs.hitGraphFromCache;
-                                break;
+                        case "attributes":
+                            value = kineticObj.getAttrs();
+                            break;
 
-                            case "attributes":
-                                value = kineticObj.getAttrs();
-                                break;
-
-                        }
-                    //}
+                    }
 
                     // this is causing the editor to cause a infinite loop
                     // need to understand why, but no time now
@@ -1460,6 +1457,28 @@ define( [ "module",
                         }
                     }
                     
+                    if ( value === undefined && kineticObj instanceof Konva.Shape ) {
+
+                        switch ( propertyName ) {
+                            
+                            case "stroke":
+                                value = kineticObj.stroke();
+                                break;
+
+                            case "strokeWidth":
+                                value = kineticObj.strokeWidth();
+                                break;
+
+                            case "strokeScaleEnabled":
+                                value = kineticObj.strokeScaleEnabled();
+                                break;
+
+                            case "strokeEnabled":
+                                value = kineticObj.strokeEnabled();
+                                break;
+                        }
+                    }
+
                     if ( value === undefined && kineticObj instanceof Konva.Sprite ) {
                         
                         switch ( propertyName ) {

--- a/support/client/lib/vwf/model/mil-sym.js
+++ b/support/client/lib/vwf/model/mil-sym.js
@@ -25,6 +25,7 @@ define( [ "module",
     function( module, model, utility, Color, cws, $ ) {
 
     var modelDriver;
+    var _pausedRenderNodes = [];
 
     return model.load( module, {
 
@@ -115,6 +116,8 @@ define( [ "module",
             if ( node === undefined ) {
 
                 if ( isUnitNode( protos ) ) {
+
+                    _pausedRenderNodes.push( childID );
 
                     this.state.nodes[ childID ] = node = this.state.createNode( "unit", nodeID, childID, childExtendsID, childImplementsIDs,
                                 childSource, childType, childIndex, childName, callback );
@@ -578,6 +581,9 @@ define( [ "module",
 
             switch( methodName ) {
                 case "render":
+                    if ( _pausedRenderNodes.includes( nodeID ) ) {
+                        _pausedRenderNodes.splice( _pausedRenderNodes.indexOf( nodeID ), 1 );
+                    }
                     value = render( node );
                     break;
             }
@@ -646,6 +652,10 @@ define( [ "module",
     function render( node ) {
 
         if ( node === undefined ) {
+            return;
+        }
+
+        if ( _pausedRenderNodes.includes( node.ID ) ) {
             return;
         }
 

--- a/support/client/lib/vwf/model/mil-sym.js
+++ b/support/client/lib/vwf/model/mil-sym.js
@@ -570,22 +570,11 @@ define( [ "module",
             return value;
         },
 
-
         // -- callingMethod --------------------------------------------------------------------------
 
-        callingMethod: function( nodeID, methodName /* [, parameter1, parameter2, ... ] */ ) { // TODO: parameters
-            
-            var node = this.state.nodes[ nodeID ]; 
-            var value = undefined;
-
-            switch( methodName ) {
-                case "render":
-                    value = render( node );
-                    break;
-            }
-
-            return value;
-        }
+        // callingMethod: function( nodeID, methodName /* [, parameter1, parameter2, ... ] */ ) { // TODO: parameters
+        //     return undefined;
+        // },
 
         // TODO: creatingEvent, deltetingEvent, firingEvent
 

--- a/support/client/lib/vwf/model/mil-sym.js
+++ b/support/client/lib/vwf/model/mil-sym.js
@@ -651,7 +651,7 @@ define( [ "module",
 
     function render( node ) {
 
-        if ( node === undefined ) {
+        if ( !( node || {} ).symbolID ) {
             return;
         }
 
@@ -661,28 +661,35 @@ define( [ "module",
 
         var value = undefined;
         
-        if ( node !== undefined && node.nodeType === "unit" && node.symbolID !== undefined ) {
-            var iconRender = armyc2.c2sd.renderer.MilStdIconRenderer;
-            var img = iconRender.Render( node.symbolID, node.modifiers );
-            
-            var centerPt = img.getCenterPoint();
-            var imgSize = img.getImageBounds();
-            var symbolBounds = img.getSymbolBounds();
+        switch( node.nodeType ) {
+            case "unit":
+                var iconRender = armyc2.c2sd.renderer.MilStdIconRenderer;
+                var img = iconRender.Render( node.symbolID, node.modifiers );
+                
+                var centerPt = img.getCenterPoint();
+                var imgSize = img.getImageBounds();
+                var symbolBounds = img.getSymbolBounds();
 
-            value = node.image = img.toDataUrl();
+                value = node.image = img.toDataUrl();
 
-            // we should really use the event, but we're having troubles
-            // getting the events to replicate, this should be switched
-            // back to the event when the replication is fixed.  handleRender
-            // can then be completely removed
-            //modelDriver.kernel.fireEvent( node.ID, "imageRendered", [ node.image, imgSize, centerPt, symbolBounds ] );
-            
-            modelDriver.kernel.callMethod( node.ID, "handleRender", [ node.image, imgSize, centerPt, symbolBounds ] );
-
-        } else if ( node !== undefined && node.nodeType === "missionGfx" && node.symbolID !== undefined ) {
-            if ( value = renderMsnGfx( node ) ) {
-                modelDriver.kernel.setProperty( node.ID, "image", value.toDataURL() );
-            }
+                // we should really use the event, but we're having troubles
+                // getting the events to replicate, this should be switched
+                // back to the event when the replication is fixed.  handleRender
+                // can then be completely removed
+                //modelDriver.kernel.fireEvent( node.ID, "imageRendered", [ node.image, imgSize, centerPt, symbolBounds ] );
+                
+                modelDriver.kernel.callMethod( node.ID, "handleRender",
+                    [ node.image, imgSize, centerPt, symbolBounds ] );
+                break;
+            case "missionGfx":
+                value = renderMsnGfx( node );
+                if ( value ) {
+                    modelDriver.kernel.setProperty( node.ID, "image", value.toDataURL() );
+                }
+                break;
+            default:
+                console.warn( "render: Cannot render node of type '", node.nodeType, "'" );
+                break;
         }
 
         return value;       

--- a/support/client/lib/vwf/model/mil-sym.js
+++ b/support/client/lib/vwf/model/mil-sym.js
@@ -115,9 +115,9 @@ define( [ "module",
 
             if ( node === undefined ) {
 
-                if ( isUnitNode( protos ) ) {
+                _pausedRenderNodes.push( childID );
 
-                    _pausedRenderNodes.push( childID );
+                if ( isUnitNode( protos ) ) {
 
                     this.state.nodes[ childID ] = node = this.state.createNode( "unit", nodeID, childID, childExtendsID, childImplementsIDs,
                                 childSource, childType, childIndex, childName, callback );
@@ -572,9 +572,12 @@ define( [ "module",
 
         // -- callingMethod --------------------------------------------------------------------------
 
-        // callingMethod: function( nodeID, methodName /* [, parameter1, parameter2, ... ] */ ) { // TODO: parameters
-        //     return undefined;
-        // },
+        callingMethod: function( nodeID, methodName /* [, parameter1, parameter2, ... ] */ ) {
+            if ( methodName === "render" ) {
+                return render( modelDriver.state.nodes[ nodeID ] );
+            }
+            return;
+        },
 
         // TODO: creatingEvent, deltetingEvent, firingEvent
 

--- a/support/client/lib/vwf/model/mil-sym.js
+++ b/support/client/lib/vwf/model/mil-sym.js
@@ -168,10 +168,9 @@ define( [ "module",
         initializingNode: function( nodeID, childID, childExtendsID, childImplementsIDs,
             childSource, childType, childIndex, childName ) {
 
-            if ( this.debug.initializing ) {
-                this.logger.infox( "initializingNode", nodeID, childID, childExtendsID, childImplementsIDs, childSource, childType, childName );
+            if ( _pausedRenderNodes.includes( childID ) ) {
+                _pausedRenderNodes.splice( _pausedRenderNodes.indexOf( childID ), 1 );
             } 
-
         },
 
         deletingNode: function( nodeID ) {
@@ -581,9 +580,6 @@ define( [ "module",
 
             switch( methodName ) {
                 case "render":
-                    if ( _pausedRenderNodes.includes( nodeID ) ) {
-                        _pausedRenderNodes.splice( _pausedRenderNodes.indexOf( nodeID ), 1 );
-                    }
                     value = render( node );
                     break;
             }

--- a/support/client/lib/vwf/view/kineticjs.js
+++ b/support/client/lib/vwf/view/kineticjs.js
@@ -1363,11 +1363,9 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color", "v
         }
 
         // Optimize and reduce line segments
-        console.info( "Points before simplify: " + ptarray.length );
         if ( ptarray.length > 2 ) {
             ptarray = simplifyJs.simplify( ptarray );
         }
-        console.info( "Points after simplify:  " + ptarray.length );
 
         // Convert back to x, y list
         var simplifiedPts = [];

--- a/support/proxy/vwf.example.com/mil-sym/missionGfx.js
+++ b/support/proxy/vwf.example.com/mil-sym/missionGfx.js
@@ -1,0 +1,3 @@
+this.initialize = function() {
+   this.future( 0 ).render();
+}

--- a/support/proxy/vwf.example.com/mil-sym/missionGfx.vwf.yaml
+++ b/support/proxy/vwf.example.com/mil-sym/missionGfx.vwf.yaml
@@ -21,5 +21,11 @@ properties:
         this.imageChanged( value );
       }
 
+methods:
+  render:
+
 events:
   imageChanged:
+
+scripts:
+- source: "missionGfx.js"

--- a/support/proxy/vwf.example.com/mil-sym/unit.js
+++ b/support/proxy/vwf.example.com/mil-sym/unit.js
@@ -1,7 +1,3 @@
-this.initialize = function() {
-    this.future( 0 ).render();
-}
-
 // The driver handles the render method
 // this.render = function() {}
 

--- a/support/proxy/vwf.example.com/mil-sym/unit.js
+++ b/support/proxy/vwf.example.com/mil-sym/unit.js
@@ -1,13 +1,12 @@
 this.initialize = function() {
-	this.future( 0.3 ).render();
+    this.future( 0 ).render();
 }
 
-// the driver will be handling this function
-//this.render = function() {}
+// The driver handles the render method
+// this.render = function() {}
 
 this.handleRender = function( img, iconSize, symbolCenter, symbolBounds ){
-    if ( this.parent !== undefined ) {
-        this.parent.handleRender( img, iconSize, symbolCenter, symbolBounds );
-    }
+    this.parent && this.parent.handleRender( img, iconSize, symbolCenter, symbolBounds );
+
+    //# sourceURL=unit.handleRender
 }
-//# sourceURL=unit.js

--- a/support/proxy/vwf.example.com/mil-sym/unit.js
+++ b/support/proxy/vwf.example.com/mil-sym/unit.js
@@ -1,6 +1,3 @@
-// The driver handles the render method
-// this.render = function() {}
-
 this.handleRender = function( img, iconSize, symbolCenter, symbolBounds ){
     this.parent && this.parent.handleRender( img, iconSize, symbolCenter, symbolBounds );
 

--- a/support/proxy/vwf.example.com/mil-sym/unit.vwf.yaml
+++ b/support/proxy/vwf.example.com/mil-sym/unit.vwf.yaml
@@ -60,25 +60,16 @@ properties:
       } 
 
 methods:
-
   handleRender:
 
 events:
-
   imageRendered:
-
   echelonChanged:
-
   affiliationChanged:
-  
   symbolIDChanged:
-
   unitStatusChanged:
-
   mobilityChanged:
-
   taskForceChanged:
-
   installationChanged:
 
 scripts:

--- a/support/proxy/vwf.example.com/mil-sym/unit.vwf.yaml
+++ b/support/proxy/vwf.example.com/mil-sym/unit.vwf.yaml
@@ -61,8 +61,6 @@ properties:
 
 methods:
 
-  render:
-
   handleRender:
 
 events:

--- a/support/proxy/vwf.example.com/mil-sym/unitGroup.js
+++ b/support/proxy/vwf.example.com/mil-sym/unitGroup.js
@@ -159,6 +159,8 @@ this.setPositionFromMapPosition = function() {
         x: this.mapPosition.x - this.scaleX * symbolCenter.x,
         y: this.mapPosition.y - this.scaleY * symbolCenter.y
     };
+
+    //# sourceURL=unitGroup.setPositionFromMapPosition
 }
 
 this.setMapPositionFromPosition = function( konvaObjectPosition, scale ) {

--- a/support/proxy/vwf.example.com/mil-sym/unitGroup.js
+++ b/support/proxy/vwf.example.com/mil-sym/unitGroup.js
@@ -41,6 +41,8 @@ this.initialize = function() {
 
     }
 
+    // Now that unitGroup is complete, show it
+    this.visible = "inherit";
 }
 
 this.handleRender = function( img, iconSize, symbolCenter, symbolBounds ){

--- a/support/proxy/vwf.example.com/mil-sym/unitIcon.js
+++ b/support/proxy/vwf.example.com/mil-sym/unitIcon.js
@@ -15,6 +15,8 @@ this.handleRender = function( img, iconSize, symbolCenter, symbolBounds ){
     if ( this.parent !== undefined ) {
         this.parent.handleRender( img, iconSize, symbolCenter, symbolBounds );
     }
+
+    //# sourceURL=unitIcon.handleRender
 }
 
 this.updateIcon = function( img, iconSize, symbolCenter ) {
@@ -30,5 +32,6 @@ this.updateIcon = function( img, iconSize, symbolCenter ) {
     // reset the unit group's "position" (upper left point)
     // to keep its center on "mapPosition" 
     this.parent.setPositionFromMapPosition();
+
+    //# sourceURL=unitIcon.updateIcon
 }
-//# sourceURL=unitIcon.js


### PR DESCRIPTION
This ensures that units, waypoints, and graphics are only rendered once they are fully created, thus eliminating the odd jumping that used to occur when a user would create something.

This corresponds to the ITDG branch `ITDG-1213-implement-route-planning-in-hololens`.