### PR TITLE
Reduce number of reflector messages on load

### DIFF
--- a/support/client/lib/vwf/view/mil-sym.js
+++ b/support/client/lib/vwf/view/mil-sym.js
@@ -102,22 +102,8 @@ define( [ "module", "vwf/view", "mil-sym/cws", "jquery" ], function( module, vie
 
         // -- calledMethod -----------------------------------------------------------------------------
 
-        calledMethod: function( nodeID, methodName, methodParameters, methodValue ) {
-
-            //console.info( nodeID + " " + methodName );
-            if ( nodeID === this.kernel.application() ) {
-                var clientThatCalledMethod = this.kernel.client();
-                var me = this.kernel.moniker();
-                switch ( methodName ) {
-
-                    case "insertUnits":
-                        if ( clientThatCalledMethod === me ) {
-                            addInsertableUnits( methodParameters[ 0 ] );
-                        }
-                        break;
-                }
-            } 
-        },
+        // calledMethod: function( nodeID, methodName, methodParameters, methodValue ) {
+        // },
 
         // -- firedEvent -----------------------------------------------------------------------------
 
@@ -131,6 +117,7 @@ define( [ "module", "vwf/view", "mil-sym/cws", "jquery" ], function( module, vie
 
         renderUnitSymbol: renderUnitSymbol,
         rendererReady: rendererReady,
+        addInsertableUnits: addInsertableUnits,
         getUpdatedUnitSymbolID: getUpdatedUnitSymbolID,
         getMissionGraphicDefinition: getMissionGraphicDefinition,
         renderMissionGraphic: renderMissionGraphic,

--- a/support/proxy/vwf.example.com/mil-sym/unitIcon.vwf.yaml
+++ b/support/proxy/vwf.example.com/mil-sym/unitIcon.vwf.yaml
@@ -27,7 +27,12 @@ properties:
 
   strokeEnabled: false
   transformsEnabled: "position"
-  zIndex: 20
+  zIndex: 20,
+  shadowColor: "rgba( 1, 1, 1, 0.5 )"
+  shadowBlur: 10
+  shadowOffsetX: 8
+  shadowOffsetY: 8
+  shadowEnabled: false
 
 methods:
   handleRender:

--- a/support/proxy/vwf.example.com/mil-sym/unitIcon.vwf.yaml
+++ b/support/proxy/vwf.example.com/mil-sym/unitIcon.vwf.yaml
@@ -27,7 +27,7 @@ properties:
 
   strokeEnabled: false
   transformsEnabled: "position"
-  zIndex: 20,
+  zIndex: 20
   shadowColor: "rgba( 1, 1, 1, 0.5 )"
   shadowBlur: 10
   shadowOffsetX: 8


### PR DESCRIPTION
This helps us avoid two reflector messages that every client was sending out unnecessarily upon load (and makes the loading of units into the unit menu and unit creation faster).

This corresponds to an app branch with the same name.