### PR TITLE
Fix unit drag synchrony

### DIFF
--- a/support/client/lib/vwf/model/kineticjs.js
+++ b/support/client/lib/vwf/model/kineticjs.js
@@ -24,7 +24,6 @@ define( [ "module",
 
             this.state = {
                 "nodes": {},
-                "draggingNodes": {},
                 "stages": {},
                 "prototypes": {},
                 "createLocalNode": function( nodeID, childID, childExtendsID, childImplementsIDs,


### PR DESCRIPTION
These changes ensure that the unit's `mapPosition` is set on `dragend` (not just on the tick updates, which would almost always miss the last little bit of motion that happened after the last tick but before `dragend`).