### PR TITLE
Increase `reflector.Evaluate` timeout to 15 seconds

### DIFF
--- a/lib/nodejs/reflector.js
+++ b/lib/nodejs/reflector.js
@@ -374,7 +374,7 @@ function Evaluate( namespace, node, expression ) {
             firstClient.pendingEvaluations.push( {
                 resolve: resolve,
                 reject: reject,
-                timeout: setTimeout( function() { reject( new Error( "timeout" ) ) }, 1000 ),
+                timeout: setTimeout( function() { reject( new Error( "timeout" ) ) }, 15000 ),
             } );
             firstClient.emit( "message", { node: node, action: "execute", parameters: [ expression ], respond: true, time: global.instances[ namespace ].getTime() } );
         } else {


### PR DESCRIPTION
When building the lobby manifest, there's a timeout on queries to the running instances to prevent a non-responsive client from hanging the manifest calculation. The timeout was previously 1 second, which was short enough to trigger if the client was busy loading or serving `getState` requests. When this happened, the scenario or session would not report any running instances in the manifest.

This PR increases the timeout to 15 seconds. That's just at the tolerable upper limit since lobby refreshes will block up to that duration when instances are slow to respond. Busy instances could plausibly wait several seconds before returning a response, so the timeout should probably not be set to less than 5 seconds.
