### PR TITLE
Handle empty files properly in OnStreamRequest

### DIFF
--- a/lib/nodejs/stream.js
+++ b/lib/nodejs/stream.js
@@ -30,32 +30,38 @@ function OnStreamRequest( request, response, parsedRequest, segments ) {
                 }
             } );
         } else {
-            var range = request.headers.range || "bytes=0-";
-            if ( range ) {
-                var positions = range.replace(/bytes=/, "").split("-");
-                var start = parseInt(positions[0], 10);
-                fs.stat( file, function( err, stats ) {
-                    if ( stats ) {
-                        var total = stats.size;
-                        var end = positions[1] ? parseInt( positions[1], 10 ) : total - 1;
-                        var chunksize = (end - start) + 1;
+            fs.stat( file, ( err, stats ) => {
+                if ( err ) {
+                    response.send( 404 );
+                    return;
+                }
 
-                        response.writeHead( 206, {
-                            "Content-Range": "bytes " + start + "-" + end + "/" + total,
-                            "Accept-Ranges": "bytes",
-                            "Content-Length": chunksize,
-                            "Content-Type": m
-                        });
-
-                        var stream = fs.createReadStream( file, { start: start, end: end } )
-                        .on( "open", function() {
-                            stream.pipe( response );
-                        }).on( "error", function( error ) {
-                            response.end( error );
-                        });
-                    }
-                });
-            }
+                const total = stats.size;
+                if ( total > 0 ) {
+                    const range = request.headers.range || "bytes=0-";
+                    const positions = range.replace( /bytes=/, "" ).split( "-" );
+                    const start = parseInt( positions[ 0 ], 10 );
+                    const end = positions[1] ? parseInt( positions[1], 10 ) : total - 1;
+                    response.writeHead( 206, {
+                        "Content-Range": "bytes " + start + "-" + end + "/" + total,
+                        "Accept-Ranges": "bytes",
+                        "Content-Length": end - start + 1,
+                        "Content-Type": m
+                    } );
+                    const stream =
+                        fs.createReadStream( file, { start: start, end: end } ).
+                            on( "open", () => stream.pipe( response ) ).
+                            on( "error", error => response.end( error ) );
+                } else {
+                    response.writeHead( 206, {
+                        "Content-Range": "bytes */0",
+                        "Accept-Ranges": "bytes",
+                        "Content-Length": 0,
+                        "Content-Type": m
+                    } );
+                    response.end();
+                }
+            } );
         }
     } else {
         response.end('');


### PR DESCRIPTION
Prior to this, if a user uploaded an empty file, the server would crash (I stumbled across this while testing some refactoring to `UTILS.uploadFileAsync`.  I tried to upload a dummy file, and boom!)

This issue was that `OnStreamRequest` would attempt to read the file from `start` (0) to `end` (`total - 1` ... which was -1).  Trying to stream from 0 to -1 cause `fs.createReadStream` to error out and crash the server.