### PR TITLE
Make getUnitImage public so that we can use it as a utility to check for valid Mil-Std 2525 symbol IDs.

### DIFF
--- a/support/client/lib/vwf/view/mil-sym.js
+++ b/support/client/lib/vwf/view/mil-sym.js
@@ -122,6 +122,7 @@ define( [ "module", "vwf/view", "mil-sym/cws", "jquery" ], function( module, vie
         getMissionGraphicDefinition: getMissionGraphicDefinition,
         renderMissionGraphic: renderMissionGraphic,
         getDefaultSymbolFillColor: getDefaultSymbolFillColor,
+        getUnitImage: getUnitImage,
 
         on: function( eventName, callback ) {
             eventHandlers[ eventName ] = callback;


### PR DESCRIPTION
Expose the existing utility function.  Using it for approach to create unit symbols from KML.