### PR TITLE
Replace res.send( 404 ) with res.sendStatus( 404 ) in stream.js

### DIFF
--- a/lib/nodejs/stream.js
+++ b/lib/nodejs/stream.js
@@ -32,7 +32,7 @@ function OnStreamRequest( request, response, parsedRequest, segments ) {
         } else {
             fs.stat( file, ( err, stats ) => {
                 if ( err ) {
-                    response.send( 404 );
+                    response.sendStatus( 404 );
                     return;
                 }
 


### PR DESCRIPTION
... which is the new way that node.js wants us to send a response that is empty other than the status code.  (Sorry, I had introduced the deprecated version a little while ago)