### PR TITLE
Add the latLonBoundBox property for mil-sym mission graphics.

### DIFF
--- a/support/client/lib/ITDG/version.js
+++ b/support/client/lib/ITDG/version.js
@@ -26,7 +26,7 @@
 /// particuarly clever about it. Take care to keep the comment and formatting intact when
 /// bumping the version number.
 
-var version = [ 0, 8, 0, "", "", [ "ITDG", 3, 2, 2 ] ];  // version-identifier
+var version = [ 0, 8, 0, "", "", [ "ITDG", 3, 3, 0 ] ];  // version-identifier
 
 /// Render the version identifier as a SemVer-style string.
 

--- a/support/client/lib/version.js
+++ b/support/client/lib/version.js
@@ -30,7 +30,7 @@ define( function() {
     /// particuarly clever about it. Take care to keep the comment and formatting intact when
     /// bumping the version number.
 
-    var version = [ 0, 8, 0, "", "", [ "ITDG", 3, 2, 2 ] ];  // version-identifier
+    var version = [ 0, 8, 0, "", "", [ "ITDG", 3, 3, 0 ] ];  // version-identifier
 
     /// Render the version identifier as a SemVer-style string.
 

--- a/support/client/lib/vwf/model/mil-sym.js
+++ b/support/client/lib/vwf/model/mil-sym.js
@@ -456,6 +456,7 @@ define( [ "module",
                         case "controlPts":
                         case "symbolType":
                         case "bounds":
+                        case "latLonBoundBox":
                             if ( node.nodeType === "missionGfx" && propertyValue !== undefined && propertyValue !== null ) {
                                 node[ propertyName ] = propertyValue;
                                 renderImage = basicPropertiesMet( node );
@@ -550,6 +551,8 @@ define( [ "module",
                     case "height":
                     case "controlPts":
                     case "symbolType":
+                    case "bounds":
+                    case "latLonBoundBox":
                         value = node[ propertyName ];
                         break;
                 }
@@ -702,9 +705,8 @@ define( [ "module",
                 symbolCode = cws.addAffiliationToSymbolId( node.symbolID, node.affiliation );
             }
             
-            var img = rendererMP.RenderSymbol2D(node.ID,node.fullName,node.description, symbolCode, controlPts, node.bounds[0], node.bounds[1], null, node.modifiers, format);
+            var img = rendererMP.RenderSymbol2D(node.ID,node.fullName,node.description, symbolCode, controlPts, node.bounds[0], node.bounds[1], ( node.latLonBoundBox || "" ), node.modifiers, format);
 
-            //if ( !!img && !!img.image ) {
             if ( ( img || {} ).image ) {
                 value = img.image;
             }

--- a/support/client/lib/vwf/view/mil-sym.js
+++ b/support/client/lib/vwf/view/mil-sym.js
@@ -356,7 +356,7 @@ define( [ "module", "vwf/view", "mil-sym/cws", "jquery" ], function( module, vie
         }
     }
 
-    function renderMissionGraphic( symbolID, affiliation, modifiers, controlPoints, bounds, msnGfx, format ) {
+    function renderMissionGraphic( symbolID, affiliation, modifiers, controlPoints, bounds, latLonBoundBox, format ) {
         
         if ( !cws ) {
             self.logger.errorx( "cws is undefined - unable to render unit icon" );
@@ -383,7 +383,7 @@ define( [ "module", "vwf/view", "mil-sym/cws", "jquery" ], function( module, vie
             actualNameModifiers[ modActualName ] = self.state.convertModifierValue( modObj, modifiers[ mod ] );
         }
 
-        var img = rendererMP.RenderSymbol2D( "ID", "Name", "Description", symbolCode, milSymControlPts, bounds[0], bounds[1], null, actualNameModifiers, format );
+        var img = rendererMP.RenderSymbol2D( "ID", "Name", "Description", symbolCode, milSymControlPts, bounds[0], bounds[1], latLonBoundBox, actualNameModifiers, format );
 
         return img;
     }

--- a/support/proxy/vwf.example.com/mil-sym/missionGfx.vwf.yaml
+++ b/support/proxy/vwf.example.com/mil-sym/missionGfx.vwf.yaml
@@ -22,6 +22,8 @@ properties:
         this.imageChanged( value );
       }
 
+  latLonBoundBox:
+
 methods:
   render:
 

--- a/support/proxy/vwf.example.com/mil-sym/unitGroup.js
+++ b/support/proxy/vwf.example.com/mil-sym/unitGroup.js
@@ -32,7 +32,7 @@ this.initialize = function() {
         }, this );
 
         this.icon.imageGenerator.imageRendered = this.events.add( function( img, iconSize, symbolCenter, symbolBounds ) {
-            
+
             if ( this.threatArea ) {
                 this.threatArea.position = this.icon.symbolCenter;    
             }

--- a/support/proxy/vwf.example.com/mil-sym/unitGroup.vwf.yaml
+++ b/support/proxy/vwf.example.com/mil-sym/unitGroup.vwf.yaml
@@ -26,6 +26,7 @@ properties:
     set: |
       if ( this.threatArea !== undefined ) {
         this.threatArea.visible = value;
+        this.handleRender();
       }
     get: |
       if ( this.threatArea !== undefined ) {


### PR DESCRIPTION
Some graphics are very particular about setting the lat/lon bounds or the resulting rendered image
will be clipped.  If the latLonBoundBox is null or blank, then mil-sym will attempt to compute its
own bounding box which may or may not have good results.

Requires ITDG app branch of same name.  See ITDG PR 331.