### PR TITLE
Super-large .tms maps were causing the VWF server to crash due to the…

### DIFF
--- a/lib/nodejs/manifest.js
+++ b/lib/nodejs/manifest.js
@@ -64,7 +64,7 @@ function applications() {
 
 function documents( applications ) {
 
-  return glob.globAsync( "documents/**/saveState?(_+([0-9])).vwf.json" ).map( function( path ) {
+  return glob.globAsync( "documents/*/!(maps)/saveState?(_+([0-9])).vwf.json" ).map( function( path ) {
 
     var match = path.match( RegExp( "documents/(.+)/([^/]+)/saveState(?:_([0-9]+))?.vwf.json" ) );
 


### PR DESCRIPTION
… number of files.  Added code to skip any directory ending with ".tms" when populating the lobby.