### PR TITLE
Follow mouse pointer to set semi-major axes' radii and prevent ellipse from becoming too skinny.

### DIFF
--- a/support/client/lib/vwf/view/kineticjs.js
+++ b/support/client/lib/vwf/view/kineticjs.js
@@ -1296,8 +1296,10 @@ define( [ "module", "vwf/view", "jquery", "vwf/utility", "vwf/utility/color", "v
                     clearBeforeDraw = true;
                     break;
 
-                case "ellipse":         
-                    drawingObject.radius( { "x": width * 0.5, "y": height * 0.5 } );
+                case "ellipse":
+                    // Prevent Konva bug where color fills screen if ellipse is too skinny
+                    const minWidth = userState.drawing_width * 2;
+                    drawingObject.radius( { "x": ( width < minWidth ? minWidth : width ), "y": ( height < minWidth ? minWidth : height ) } );
                     drawingObject.stroke( userState.drawing_color );
                     drawingObject.strokeWidth( userState.drawing_width );
                     drawingObject.fill( null );


### PR DESCRIPTION

Konva has an issue where if the ellipse becomes too skinny in height, the entire window will fill
with the color of the ellipse.

Complements ITDG pull request with same branch name.