### PR TITLE
Fix overlay cache becoming corrupted

### DIFF
--- a/lib/nodejs/sandtable.js
+++ b/lib/nodejs/sandtable.js
@@ -123,7 +123,7 @@ function getFromCache(params) {
 }
 
 function clearRequestCache() {
-    requestCache = {};
+    requestCache = [];
 }
 
 function clearRequestQueue() {


### PR DESCRIPTION
A bug from my previous merge request allowed the overlay cache to become corrupted by changing the type of an array to an object, resulting in all calls to generate overlays returning an error. This is a line I overlooked in my previous PR.